### PR TITLE
Example fallback

### DIFF
--- a/src/tensor_ops.cpp
+++ b/src/tensor_ops.cpp
@@ -296,7 +296,12 @@ using c10::DeviceType;
         return res;
     }
 
-
+    void fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack)
+    {
+      TORCH_CHECK(false, "The operator '", op.schema().operator_name(), "' is not currently ",
+                  "supported on the ocl backend. Please open an issue at for requesting support "
+                  "https://github.com/artyom-beilis/pytorch_dlprim/issues");
+    }
 
 } // namespace dtype
 
@@ -311,4 +316,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
       m.impl("aten::as_strided",&ptdlprim::as_strided);
       m.impl("aten::_local_scalar_dense",&ptdlprim::_local_scalar_dense);
       m.impl("aten::masked_select",&ptdlprim::masked_select);
+}
+TORCH_LIBRARY_IMPL(_, PrivateUse1, m) {
+      m.fallback(torch::CppFunction::makeFromBoxedFunction<&ptdlprim::fallback>());
 }

--- a/src/tensor_ops.cpp
+++ b/src/tensor_ops.cpp
@@ -1,5 +1,6 @@
 #include "CLTensor.h"
 #include "utils.h"
+#include <ATen/native/CPUFallback.h>
 
 #include <dlprim/core/util.hpp>
 #include <dlprim/core/pointwise.hpp>
@@ -298,9 +299,10 @@ using c10::DeviceType;
 
     void fallback(const c10::OperatorHandle& op, torch::jit::Stack* stack)
     {
-      TORCH_CHECK(false, "The operator '", op.schema().operator_name(), "' is not currently ",
-                  "supported on the ocl backend. Please open an issue at for requesting support "
-                  "https://github.com/artyom-beilis/pytorch_dlprim/issues");
+      TORCH_WARN("The operator '", op.schema().operator_name(), "' is not currently ",
+                 "supported on the ocl backend. Please open an issue at for requesting support "
+                 "https://github.com/artyom-beilis/pytorch_dlprim/issues");
+      native::cpu_fallback(op, stack);
     }
 
 } // namespace dtype


### PR DESCRIPTION
@artyom-beilis if you want to improve the error message when an op is not implemented for ocl (first commit) or make it fallback to using the CPU for ops that are not implemented (second commit).

You don't have to merge this, but I felt  it was the simplest way to share the idea with you!
If you want some other variation of this, feel free to share it and we can see what can be done!